### PR TITLE
Allow local parmeters if mapped arguments object is not used

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -5,8 +5,8 @@ permissions:
 # Schedule this workflow to run at midnight every day
 on:
   schedule:
-    - cron: "0 0 * * *"  
-  workflow_dispatch: 
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -16,7 +16,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-14
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, macos, win-msvc]
+        build: [linux, macos-amd64, macos-arm64, win-msvc]
         include:
         - build: linux
           os: ubuntu-20.04
@@ -90,11 +90,17 @@ jobs:
           target: x86_64-unknown-linux-gnu
           asset_name: boa-linux-amd64
           binary_name: boa
-        - build: macos
-          os: macos-latest
+        - build: macos-amd64
+          os: macos-13
           rust: stable
           target: x86_64-apple-darwin
           asset_name: boa-macos-amd64
+          binary_name: boa
+        - build: macos-arm64
+          os: macos-14
+          rust: stable
+          target: aarch64-apple-darwin
+          asset_name: boa-macos-arm64
           binary_name: boa
         - build: win-msvc
           os: windows-2019

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,10 +66,12 @@ jobs:
       # TODO: Make a small Rust tool that does this
       CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
       CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
+      CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
+          - macos-14
           - windows-latest
     steps:
       - name: Checkout repository

--- a/core/ast/src/position.rs
+++ b/core/ast/src/position.rs
@@ -176,7 +176,7 @@ impl fmt::Display for Span {
 /// Note that linear spans are of the form [start, end) i.e. that the
 /// start position is inclusive and the end position is exclusive.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LinearSpan {
     start: LinearPosition,
     end: LinearPosition,

--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -584,6 +584,7 @@ pub struct FunctionScopes {
     pub(crate) parameters_eval_scope: Option<Scope>,
     pub(crate) parameters_scope: Option<Scope>,
     pub(crate) lexical_scope: Option<Scope>,
+    pub(crate) mapped_arguments_object: bool,
 }
 
 impl FunctionScopes {
@@ -701,6 +702,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FunctionScopes {
             parameters_eval_scope: None,
             parameters_scope: None,
             lexical_scope: None,
+            mapped_arguments_object: false,
         })
     }
 }

--- a/core/ast/tests/scope.rs
+++ b/core/ast/tests/scope.rs
@@ -1,0 +1,239 @@
+//! Tests for the scope analysis of the AST.
+
+#![allow(unused_crate_dependencies)]
+
+use boa_ast::{
+    declaration::{LexicalDeclaration, Variable},
+    expression::Identifier,
+    function::{FormalParameter, FormalParameterList, FunctionBody, FunctionDeclaration},
+    scope::Scope,
+    statement::Block,
+    Declaration, Expression, Script, Statement, StatementList, StatementListItem,
+};
+use boa_interner::Interner;
+use boa_string::JsString;
+
+#[test]
+fn empty_script_is_ok() {
+    let scope = &Scope::new_global();
+    let mut script = Script::default();
+    let ok = script.analyze_scope(scope, &Interner::new());
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+}
+
+#[test]
+fn script_global_let() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::Lexical(LexicalDeclaration::Let(
+            vec![Variable::from_identifier(a.into(), None)]
+                .try_into()
+                .unwrap(),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 1);
+    let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(!a.local());
+}
+
+#[test]
+fn script_global_const() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::Lexical(LexicalDeclaration::Const(
+            vec![Variable::from_identifier(a.into(), None)]
+                .try_into()
+                .unwrap(),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 1);
+    let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(!a.local());
+}
+
+#[test]
+fn script_block_let() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Statement::Block(Block::from(vec![Declaration::Lexical(
+            LexicalDeclaration::Let(
+                vec![Variable::from_identifier(a.into(), None)]
+                    .try_into()
+                    .unwrap(),
+            ),
+        )
+        .into()]))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+    let StatementListItem::Statement(Statement::Block(block)) =
+        script.statements().first().unwrap()
+    else {
+        panic!("Expected a block statement");
+    };
+    let scope = block.scope().unwrap();
+    assert_eq!(scope.num_bindings(), 1);
+    let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+}
+
+#[test]
+fn script_function_mapped_arguments_not_accessed() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let f = interner.get_or_intern("f");
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::FunctionDeclaration(FunctionDeclaration::new(
+            f.into(),
+            FormalParameterList::from_parameters(vec![FormalParameter::new(
+                Variable::from_identifier(a.into(), None),
+                false,
+            )]),
+            FunctionBody::new(
+                [Declaration::Lexical(LexicalDeclaration::Let(
+                    vec![Variable::from_identifier(a.into(), None)]
+                        .try_into()
+                        .unwrap(),
+                ))
+                .into()],
+                false,
+            ),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+    let StatementListItem::Declaration(Declaration::FunctionDeclaration(f)) =
+        script.statements().first().unwrap()
+    else {
+        panic!("Expected a block statement");
+    };
+    assert_eq!(f.scopes().function_scope().num_bindings(), 2);
+    assert_eq!(f.scopes().parameters_eval_scope(), None);
+    assert_eq!(f.scopes().parameters_scope(), None);
+    assert_eq!(f.scopes().lexical_scope().unwrap().num_bindings(), 1);
+    let arguments = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("arguments"))
+        .unwrap();
+    assert!(!f.scopes().arguments_object_accessed());
+    assert!(!arguments.is_global_object());
+    assert!(arguments.is_lexical());
+    assert!(arguments.local());
+    let a = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+    let a = f
+        .scopes()
+        .lexical_scope()
+        .unwrap()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+}
+
+#[test]
+fn script_function_mapped_arguments_accessed() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let f = interner.get_or_intern("f");
+    let a = interner.get_or_intern("a");
+    let arguments = interner.get_or_intern("arguments");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::FunctionDeclaration(FunctionDeclaration::new(
+            f.into(),
+            FormalParameterList::from_parameters(vec![FormalParameter::new(
+                Variable::from_identifier(a.into(), None),
+                false,
+            )]),
+            FunctionBody::new(
+                [
+                    Declaration::Lexical(LexicalDeclaration::Let(
+                        vec![Variable::from_identifier(a.into(), None)]
+                            .try_into()
+                            .unwrap(),
+                    ))
+                    .into(),
+                    Statement::Expression(Expression::Identifier(Identifier::new(arguments)))
+                        .into(),
+                ],
+                false,
+            ),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+    let StatementListItem::Declaration(Declaration::FunctionDeclaration(f)) =
+        script.statements().first().unwrap()
+    else {
+        panic!("Expected a block statement");
+    };
+    assert!(f.scopes().arguments_object_accessed());
+    assert_eq!(f.scopes().function_scope().num_bindings(), 2);
+    assert_eq!(f.scopes().parameters_eval_scope(), None);
+    assert_eq!(f.scopes().parameters_scope(), None);
+    assert_eq!(f.scopes().lexical_scope().unwrap().num_bindings(), 1);
+    let arguments = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("arguments"))
+        .unwrap();
+    assert!(!arguments.is_global_object());
+    assert!(arguments.is_lexical());
+    assert!(arguments.local());
+    let a = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(!a.local());
+    let a = f
+        .scopes()
+        .lexical_scope()
+        .unwrap()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+}

--- a/core/ast/tests/scope.rs
+++ b/core/ast/tests/scope.rs
@@ -8,7 +8,8 @@ use boa_ast::{
     function::{FormalParameter, FormalParameterList, FunctionBody, FunctionDeclaration},
     scope::Scope,
     statement::Block,
-    Declaration, Expression, Script, Statement, StatementList, StatementListItem,
+    Declaration, Expression, LinearPosition, LinearSpan, Script, Statement, StatementList,
+    StatementListItem,
 };
 use boa_interner::Interner;
 use boa_string::JsString;
@@ -34,6 +35,7 @@ fn script_global_let() {
                 .unwrap(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -57,6 +59,7 @@ fn script_global_const() {
                 .unwrap(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -74,15 +77,17 @@ fn script_block_let() {
     let mut interner = Interner::new();
     let a = interner.get_or_intern("a");
     let mut script = Script::new(StatementList::new(
-        [Statement::Block(Block::from(vec![Declaration::Lexical(
-            LexicalDeclaration::Let(
+        [Statement::Block(Block::from((
+            vec![Declaration::Lexical(LexicalDeclaration::Let(
                 vec![Variable::from_identifier(a.into(), None)]
                     .try_into()
                     .unwrap(),
-            ),
-        )
-        .into()]))
+            ))
+            .into()],
+            LinearPosition::default(),
+        )))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -121,10 +126,13 @@ fn script_function_mapped_arguments_not_accessed() {
                         .unwrap(),
                 ))
                 .into()],
+                LinearPosition::default(),
                 false,
             ),
+            LinearSpan::default(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -192,10 +200,13 @@ fn script_function_mapped_arguments_accessed() {
                     Statement::Expression(Expression::Identifier(Identifier::new(arguments)))
                         .into(),
                 ],
+                LinearPosition::default(),
                 false,
             ),
+            LinearSpan::default(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -194,6 +194,7 @@ impl IntrinsicObject for Duration {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::total, js_string!("total"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -858,6 +859,29 @@ impl Duration {
         Ok(JsString::from(result).into())
     }
 
+    // TODO: Potentially update docs if localeString is inverted.
+    /// 7.3.24 `Temporal.Duration.prototype.toLocaleString ( )`
+    pub(crate) fn to_locale_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let duration = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a Duration object.")
+            })?;
+
+        let result = duration
+            .inner
+            .as_temporal_string(ToStringRoundingOptions::default())?;
+
+        Ok(JsString::from(result).into())
+    }
+
+    /// 7.3.25 `Temporal.Duration.prototype.valueOf ( )`
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -92,8 +92,8 @@ impl IntrinsicObject for Instant {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
-            .method(Self::to_zoned_date_time, js_string!("toZonedDateTime"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .method(
@@ -457,30 +457,7 @@ impl Instant {
         Ok(true.into())
     }
 
-    /// 8.3.17 `Temporal.Instant.prototype.toZonedDateTime ( item )`
-    pub(crate) fn to_zoned_date_time(
-        _: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
-    ) -> JsResult<JsValue> {
-        // TODO: Complete
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
-            .into())
-    }
-
-    /// 8.3.18 `Temporal.Instant.prototype.toZonedDateTimeISO ( timeZone )`
-    pub(crate) fn to_zoned_date_time_iso(
-        _: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
-    ) -> JsResult<JsValue> {
-        // TODO Complete
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
-            .into())
-    }
-
+    /// 8.3.11 `Temporal.Instant.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let instant = this
             .as_object()
@@ -518,6 +495,26 @@ impl Instant {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 8.3.12 `Temporal.Instant.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let instant = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("the this object must be a Temporal.Instant object.")
+            })?;
+
+        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
+            None,
+            ToStringRoundingOptions::default(),
+            context.tz_provider(),
+        )?;
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 8.3.13 `Temporal.Instant.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let instant = this
             .as_object()
@@ -535,9 +532,22 @@ impl Instant {
         Ok(JsString::from(ixdtf).into())
     }
 
-    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    /// 8.3.14 `Temporal.Instant.prototype.valueOf ( )`
+    fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
+            .into())
+    }
+
+    /// 8.3.15 `Temporal.Instant.prototype.toZonedDateTimeISO ( timeZone )`
+    pub(crate) fn to_zoned_date_time_iso(
+        _: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO Complete
+        Err(JsNativeError::error()
+            .with_message("not yet implemented.")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -37,24 +37,13 @@ use crate::{
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
-    Context, JsBigInt, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
+    Context, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
 };
 use boa_profiler::Profiler;
 use temporal_rs::options::RelativeTo;
 use temporal_rs::{
     primitive::FiniteF64, PlainDate as TemporalDate, ZonedDateTime as TemporalZonedDateTime,
-    NS_PER_DAY,
 };
-
-// TODO: Remove in favor of `temporal_rs`
-pub(crate) fn ns_max_instant() -> JsBigInt {
-    JsBigInt::from(i128::from(NS_PER_DAY) * 100_000_000_i128)
-}
-
-// TODO: Remove in favor of `temporal_rs`
-pub(crate) fn ns_min_instant() -> JsBigInt {
-    JsBigInt::from(i128::from(NS_PER_DAY) * -100_000_000_i128)
-}
 
 // An enum representing common fields across `Temporal` objects.
 pub(crate) enum DateTimeValues {

--- a/core/engine/src/builtins/temporal/now.rs
+++ b/core/engine/src/builtins/temporal/now.rs
@@ -7,16 +7,14 @@ use crate::{
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
-    sys::time::SystemTime,
-    Context, JsBigInt, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
+    Context, JsArgs, JsObject, JsResult, JsString, JsSymbol, JsValue,
 };
 use boa_profiler::Profiler;
-use temporal_rs::{Now as NowInner, TimeZone};
+use temporal_rs::Now as NowInner;
 
 use super::{
     create_temporal_date, create_temporal_datetime, create_temporal_instant, create_temporal_time,
-    create_temporal_zoneddatetime, ns_max_instant, ns_min_instant, time_zone::default_time_zone,
-    to_temporal_timezone_identifier,
+    create_temporal_zoneddatetime, to_temporal_timezone_identifier,
 };
 
 /// JavaScript `Temporal.Now` object.
@@ -65,12 +63,9 @@ impl Now {
     ///
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.now.timezone
     #[allow(clippy::unnecessary_wraps)]
-    fn time_zone_id(_: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn time_zone_id(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Return ! SystemTimeZone().
-        system_time_zone(context)?
-            .identifier()
-            .map(|s| JsValue::from(js_string!(s.as_str())))
-            .map_err(Into::into)
+        Ok(JsString::from(NowInner::time_zone_id()?).into())
     }
 
     /// `Temporal.Now.instant()`
@@ -81,7 +76,7 @@ impl Now {
     /// `Temporal.Now.plainDateTime()`
     fn plain_datetime(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let tz = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         create_temporal_datetime(
@@ -95,7 +90,7 @@ impl Now {
     /// `Temporal.Now.zonedDateTime`
     fn zoneddatetime(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let timezone = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         let zdt = NowInner::zoneddatetime_iso(timezone)?;
@@ -105,7 +100,7 @@ impl Now {
     /// `Temporal.Now.plainDateISO`
     fn plain_date(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let tz = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         let pd = NowInner::plain_date_iso_with_provider(tz, context.tz_provider())?;
@@ -114,76 +109,10 @@ impl Now {
 
     fn plain_time(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let tz = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         let pt = NowInner::plain_time_iso_with_provider(tz, context.tz_provider())?;
         create_temporal_time(pt, None, context).map(Into::into)
     }
-}
-
-// -- Temporal.Now abstract operations --
-
-/// 2.3.1 `HostSystemUTCEpochNanoseconds ( global )`
-fn host_system_utc_epoch_nanoseconds() -> JsResult<JsBigInt> {
-    // TODO: Implement `SystemTime::now()` calls for `no_std`
-    let epoch_nanos = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|e| JsNativeError::range().with_message(e.to_string()))?
-        .as_nanos();
-    Ok(clamp_epoc_nanos(JsBigInt::from(epoch_nanos)))
-}
-
-fn clamp_epoc_nanos(ns: JsBigInt) -> JsBigInt {
-    let max = ns_max_instant();
-    let min = ns_min_instant();
-    ns.clamp(min, max)
-}
-
-/// 2.3.2 `SystemUTCEpochMilliseconds`
-#[allow(unused)]
-fn system_utc_epoch_millis() -> JsResult<f64> {
-    let now = host_system_utc_epoch_nanoseconds()?;
-    Ok(now.to_f64().div_euclid(1_000_000_f64).floor())
-}
-
-/// 2.3.3 `SystemUTCEpochNanoseconds`
-#[allow(unused)]
-fn system_utc_epoch_nanos() -> JsResult<JsBigInt> {
-    host_system_utc_epoch_nanoseconds()
-}
-
-/// `SystemInstant`
-#[allow(unused)]
-fn system_instant() {
-    todo!()
-}
-
-/// `SystemDateTime`
-#[allow(unused)]
-fn system_date_time() {
-    todo!()
-}
-
-/// `SystemZonedDateTime`
-#[allow(unused)]
-fn system_zoned_date_time() {
-    todo!()
-}
-
-/// Abstract operation `SystemTimeZone ( )`
-///
-/// More information:
-///  - [ECMAScript specififcation][spec]
-///
-/// [spec]: https://tc39.es/proposal-temporal/#sec-temporal-systemtimezone
-#[allow(unused)]
-fn system_time_zone(context: &mut Context) -> JsResult<TimeZone> {
-    // 1. Let identifier be ! DefaultTimeZone().
-    let identifier = default_time_zone(context);
-    // 2. Return ! CreateTemporalTimeZone(identifier).
-
-    Err(JsNativeError::error()
-        .with_message("not yet implemented.")
-        .into())
 }

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -69,6 +69,14 @@ impl IntrinsicObject for PlainDateTime {
             .name(js_string!("get calendarId"))
             .build();
 
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+            .name(js_string!("get era"))
+            .build();
+
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+            .name(js_string!("get eraYear"))
+            .build();
+
         let get_year = BuiltInBuilder::callable(realm, Self::get_year)
             .name(js_string!("get year"))
             .build();
@@ -154,6 +162,18 @@ impl IntrinsicObject for PlainDateTime {
             .accessor(
                 js_string!("calendarId"),
                 Some(get_calendar_id),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("era"),
+                Some(get_era),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("eraYear"),
+                Some(get_era_year),
                 None,
                 Attribute::CONFIGURABLE,
             )
@@ -283,6 +303,7 @@ impl IntrinsicObject for PlainDateTime {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -416,6 +437,34 @@ impl PlainDateTime {
     }
 
     /// 5.3.4 get `Temporal.PlainDatedt.prototype.year`
+    fn get_era(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        Ok(dt
+            .inner
+            .era()?
+            .map(|s| JsString::from(s.as_str()))
+            .into_or_undefined())
+    }
+
+    /// 5.3.5 get `Temporal.PlainDatedt.prototype.eraYear`
+    fn get_era_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        Ok(dt.inner.era_year()?.into_or_undefined())
+    }
+
+    /// 5.3.6 get `Temporal.PlainDatedt.prototype.year`
     fn get_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -427,7 +476,7 @@ impl PlainDateTime {
         Ok(dt.inner.year()?.into())
     }
 
-    /// 5.3.5 get `Temporal.PlainDatedt.prototype.month`
+    /// 5.3.7 get `Temporal.PlainDatedt.prototype.month`
     fn get_month(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -439,7 +488,7 @@ impl PlainDateTime {
         Ok(dt.inner.month()?.into())
     }
 
-    /// 5.3.6 get Temporal.PlainDatedt.prototype.monthCode
+    /// 5.3.8 get Temporal.PlainDatedt.prototype.monthCode
     fn get_month_code(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -451,7 +500,7 @@ impl PlainDateTime {
         Ok(JsString::from(dt.inner.month_code()?.as_str()).into())
     }
 
-    /// 5.3.7 get `Temporal.PlainDatedt.prototype.day`
+    /// 5.3.9 get `Temporal.PlainDatedt.prototype.day`
     fn get_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -463,7 +512,7 @@ impl PlainDateTime {
         Ok(dt.inner.day()?.into())
     }
 
-    /// 5.3.8 get `Temporal.PlainDatedt.prototype.hour`
+    /// 5.3.10 get `Temporal.PlainDatedt.prototype.hour`
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -478,7 +527,7 @@ impl PlainDateTime {
         Ok(dt.inner.hour().into())
     }
 
-    /// 5.3.9 get `Temporal.PlainDatedt.prototype.minute`
+    /// 5.3.11 get `Temporal.PlainDatedt.prototype.minute`
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -493,7 +542,7 @@ impl PlainDateTime {
         Ok(dt.inner.minute().into())
     }
 
-    /// 5.3.10 get `Temporal.PlainDatedt.prototype.second`
+    /// 5.3.12 get `Temporal.PlainDatedt.prototype.second`
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -508,7 +557,7 @@ impl PlainDateTime {
         Ok(dt.inner.second().into())
     }
 
-    /// 5.3.11 get `Temporal.PlainDatedt.prototype.millisecond`
+    /// 5.3.13 get `Temporal.PlainDatedt.prototype.millisecond`
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -523,7 +572,7 @@ impl PlainDateTime {
         Ok(dt.inner.millisecond().into())
     }
 
-    /// 5.3.12 get `Temporal.PlainDatedt.prototype.microsecond`
+    /// 5.3.14 get `Temporal.PlainDatedt.prototype.microsecond`
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -538,7 +587,7 @@ impl PlainDateTime {
         Ok(dt.inner.microsecond().into())
     }
 
-    /// 5.3.13 get `Temporal.PlainDatedt.prototype.nanosecond`
+    /// 5.3.15 get `Temporal.PlainDatedt.prototype.nanosecond`
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -553,7 +602,7 @@ impl PlainDateTime {
         Ok(dt.inner.nanosecond().into())
     }
 
-    /// 5.3.14 get `Temporal.PlainDatedt.prototype.dayOfWeek`
+    /// 5.3.16 get `Temporal.PlainDatedt.prototype.dayOfWeek`
     fn get_day_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -565,7 +614,7 @@ impl PlainDateTime {
         Ok(dt.inner.day_of_week()?.into())
     }
 
-    /// 5.3.15 get `Temporal.PlainDatedt.prototype.dayOfYear`
+    /// 5.3.17 get `Temporal.PlainDatedt.prototype.dayOfYear`
     fn get_day_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -577,7 +626,7 @@ impl PlainDateTime {
         Ok(dt.inner.day_of_year()?.into())
     }
 
-    /// 5.3.16 get `Temporal.PlainDatedt.prototype.weekOfYear`
+    /// 5.3.18 get `Temporal.PlainDatedt.prototype.weekOfYear`
     fn get_week_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -589,7 +638,7 @@ impl PlainDateTime {
         Ok(dt.inner.week_of_year()?.into_or_undefined())
     }
 
-    /// 5.3.17 get `Temporal.PlainDatedt.prototype.yearOfWeek`
+    /// 5.3.19 get `Temporal.PlainDatedt.prototype.yearOfWeek`
     fn get_year_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -601,7 +650,7 @@ impl PlainDateTime {
         Ok(dt.inner.year_of_week()?.into_or_undefined())
     }
 
-    /// 5.3.18 get `Temporal.PlainDatedt.prototype.daysInWeek`
+    /// 5.3.20 get `Temporal.PlainDatedt.prototype.daysInWeek`
     fn get_days_in_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -613,7 +662,7 @@ impl PlainDateTime {
         Ok(dt.inner.days_in_week()?.into())
     }
 
-    /// 5.3.19 get `Temporal.PlainDatedt.prototype.daysInMonth`
+    /// 5.3.21 get `Temporal.PlainDatedt.prototype.daysInMonth`
     fn get_days_in_month(
         this: &JsValue,
         _: &[JsValue],
@@ -629,7 +678,7 @@ impl PlainDateTime {
         Ok(dt.inner.days_in_month()?.into())
     }
 
-    /// 5.3.20 get `Temporal.PlainDatedt.prototype.daysInYear`
+    /// 5.3.22 get `Temporal.PlainDatedt.prototype.daysInYear`
     fn get_days_in_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -641,7 +690,7 @@ impl PlainDateTime {
         Ok(dt.inner.days_in_year()?.into())
     }
 
-    /// 5.3.21 get `Temporal.PlainDatedt.prototype.monthsInYear`
+    /// 5.3.23 get `Temporal.PlainDatedt.prototype.monthsInYear`
     fn get_months_in_year(
         this: &JsValue,
         _: &[JsValue],
@@ -657,7 +706,7 @@ impl PlainDateTime {
         Ok(dt.inner.months_in_year()?.into())
     }
 
-    /// 5.3.22 get `Temporal.PlainDatedt.prototype.inLeapYear`
+    /// 5.3.24 get `Temporal.PlainDatedt.prototype.inLeapYear`
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -978,6 +1027,27 @@ impl PlainDateTime {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 5.3.35 `Temporal.PlainDateTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        let ixdtf = dt
+            .inner
+            .to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto)?;
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 5.3.36 `Temporal.PlainDateTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -992,6 +1062,7 @@ impl PlainDateTime {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 5.3.37 `Temporal.PlainDateTime.prototype.valueOf ( )`
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -83,7 +83,9 @@ impl IntrinsicObject for PlainMonthDay {
                 Attribute::CONFIGURABLE,
             )
             .static_method(Self::from, js_string!("from"), 1)
+            .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -164,7 +166,8 @@ impl PlainMonthDay {
     fn from(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let options = get_options_object(args.get_or_undefined(1))?;
         let item = args.get_or_undefined(0);
-        to_temporal_month_day(item, &options, context)
+        let inner = to_temporal_month_day(item, Some(options), context)?;
+        create_temporal_month_day(inner, None, context)
     }
 }
 
@@ -208,6 +211,19 @@ impl PlainMonthDay {
 // ==== `Temporal.PlainMonthDay` Methods ====
 
 impl PlainMonthDay {
+    fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let month_day = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
+            })?;
+
+        let other = to_temporal_month_day(args.get_or_undefined(0), None, context)?;
+
+        Ok((month_day.inner == other).into())
+    }
+
     /// 10.3.8 `Temporal.PlainMonthDay.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
@@ -231,7 +247,24 @@ impl PlainMonthDay {
         Ok(JsString::from(ixdtf).into())
     }
 
-    /// 10.3.10 Temporal.PlainMonthDay.prototype.toJSON ( )
+    /// 10.3.9 `Temporal.PlainMonthDay.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    pub(crate) fn to_locale_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let month_day = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
+            })?;
+
+        Ok(JsString::from(month_day.inner.to_string()).into())
+    }
+
+    /// 10.3.10 `Temporal.PlainMonthDay.prototype.toJSON ( )`
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let month_day = this
             .as_object()
@@ -243,7 +276,7 @@ impl PlainMonthDay {
         Ok(JsString::from(month_day.inner.to_string()).into())
     }
 
-    /// 9.3.11 Temporal.PlainMonthDay.prototype.valueOf ( )
+    /// 9.3.11 `Temporal.PlainMonthDay.prototype.valueOf ( )`
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
@@ -293,26 +326,23 @@ pub(crate) fn create_temporal_month_day(
 
 fn to_temporal_month_day(
     item: &JsValue,
-    options: &JsObject,
+    options: Option<JsObject>,
     context: &mut Context,
-) -> JsResult<JsValue> {
-    let overflow = get_option::<ArithmeticOverflow>(options, js_string!("overflow"), context)?
+) -> JsResult<InnerMonthDay> {
+    let options = options.unwrap_or(JsObject::with_null_proto());
+    let overflow = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?
         .unwrap_or(ArithmeticOverflow::Constrain);
 
     // get the calendar property (string) from the item object
     let calender_id = item.get_v(js_string!("calendar"), context)?;
     let calendar = to_temporal_calendar_slot_value(&calender_id)?;
 
-    let inner = if let Some(item_obj) = item
-        .as_object()
-        .and_then(JsObject::downcast_ref::<PlainMonthDay>)
-    {
-        item_obj.inner.clone()
-    } else if let Some(item_string) = item.as_string() {
-        InnerMonthDay::from_str(item_string.to_std_string_escaped().as_str())?
-    } else if item.is_object() {
-        let day = item
-            .get_v(js_string!("day"), context)?
+    if let Some(obj) = item.as_object() {
+        if let Some(md) = obj.downcast_ref::<PlainMonthDay>() {
+            return Ok(md.inner.clone());
+        }
+        let day = obj
+            .get(js_string!("day"), context)?
             .map(|v| {
                 let finite = v.to_finitef64(context)?;
                 finite
@@ -321,8 +351,8 @@ fn to_temporal_month_day(
             })
             .transpose()?;
 
-        let month = item
-            .get_v(js_string!("month"), context)?
+        let month = obj
+            .get(js_string!("month"), context)?
             .map(|v| {
                 let finite = v.to_finitef64(context)?;
                 finite
@@ -331,8 +361,8 @@ fn to_temporal_month_day(
             })
             .transpose()?;
 
-        let month_code = item
-            .get_v(js_string!("monthCode"), context)?
+        let month_code = obj
+            .get(js_string!("monthCode"), context)?
             .map(|v| {
                 let primitive = v.to_primitive(context, crate::value::PreferredType::String)?;
                 let Some(month_code) = primitive.as_string() else {
@@ -345,12 +375,12 @@ fn to_temporal_month_day(
             })
             .transpose()?;
 
-        let year =
-            item.get_v(js_string!("year"), context)?
-                .map_or(Ok::<i32, JsError>(1972), |v| {
-                    let finite = v.to_finitef64(context)?;
-                    Ok(finite.as_integer_with_truncation::<i32>())
-                })?;
+        let year = obj
+            .get(js_string!("year"), context)?
+            .map_or(Ok::<i32, JsError>(1972), |v| {
+                let finite = v.to_finitef64(context)?;
+                Ok(finite.as_integer_with_truncation::<i32>())
+            })?;
 
         let partial_date = &PartialDate {
             month,
@@ -360,12 +390,16 @@ fn to_temporal_month_day(
             ..Default::default()
         };
 
-        calendar.month_day_from_partial(partial_date, overflow)?
-    } else {
+        return Ok(calendar.month_day_from_partial(partial_date, overflow)?);
+    }
+
+    let Some(md_string) = item.as_string() else {
         return Err(JsNativeError::typ()
             .with_message("item must be an object or a string")
             .into());
     };
 
-    create_temporal_month_day(inner, None, context)
+    Ok(InnerMonthDay::from_str(
+        md_string.to_std_string_escaped().as_str(),
+    )?)
 }

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -119,6 +119,7 @@ impl IntrinsicObject for PlainTime {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -556,6 +557,22 @@ impl PlainTime {
 
         let ixdtf = time.inner.to_ixdtf_string(options)?;
 
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 4.3.17 `Temporal.PlainTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let time = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
+            })?;
+
+        let ixdtf = time
+            .inner
+            .to_ixdtf_string(ToStringRoundingOptions::default())?;
         Ok(JsString::from(ixdtf).into())
     }
 

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -351,6 +351,7 @@ impl IntrinsicObject for ZonedDateTime {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .method(Self::start_of_day, js_string!("startOfDay"), 0)
@@ -1053,6 +1054,28 @@ impl ZonedDateTime {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 6.3.42 `Temporal.ZonedDateTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let zdt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
+            })?;
+
+        let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
+            DisplayOffset::Auto,
+            DisplayTimeZone::Auto,
+            DisplayCalendar::Auto,
+            ToStringRoundingOptions::default(),
+            context.tz_provider(),
+        )?;
+
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 6.3.43 `Temporal.ZonedDateTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let zdt = this
             .as_object()

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -521,9 +521,21 @@ impl Context {
     }
 
     /// Retrieves the current stack trace of the context.
+    ///
+    /// The stack trace is returned ordered with the most recent frames first.
     #[inline]
     pub fn stack_trace(&self) -> impl Iterator<Item = &CallFrame> {
-        self.vm.frames.iter().rev()
+        // Create a list containing the previous frames plus the current frame.
+        let frames: Vec<_> = self
+            .vm
+            .frames
+            .iter()
+            .chain(std::iter::once(&self.vm.frame))
+            .collect();
+
+        // The first frame is always a dummy frame (see `Vm` implementation for more details),
+        // so skip the dummy frame and return the reversed list so that the most recent frames are first.
+        frames.into_iter().skip(1).rev()
     }
 
     /// Replaces the currently active realm with `realm`, and returns the old realm.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:

-
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of function parameters when an arguments object is involved, improving the accuracy of parameter binding in functions.
  - Added new methods for locale-sensitive string representation across various temporal structures, including `Duration`, `Instant`, `PlainDate`, `PlainDateTime`, `PlainMonthDay`, `PlainTime`, `PlainYearMonth`, and `ZonedDateTime`.

- **Tests**
  - Introduced a comprehensive test suite to validate scope analysis across multiple contexts, including global, block, and function level scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->